### PR TITLE
qcom: Select Sony display/media variants for Sony devices

### DIFF
--- a/core/qcom_target.mk
+++ b/core/qcom_target.mk
@@ -65,8 +65,14 @@ ifeq ($(BOARD_USES_QCOM_HARDWARE),true)
     endif
 
 $(call project-set-path,qcom-audio,hardware/qcom/audio-caf/$(QCOM_HARDWARE_VARIANT))
+
+ifeq ($(SONY_BF64_KERNEL_VARIANT),true)
+$(call project-set-path,qcom-display,hardware/qcom/display-caf/sony)
+$(call project-set-path,qcom-media,hardware/qcom/media-caf/sony)
+else
 $(call project-set-path,qcom-display,hardware/qcom/display-caf/$(QCOM_HARDWARE_VARIANT))
 $(call project-set-path,qcom-media,hardware/qcom/media-caf/$(QCOM_HARDWARE_VARIANT))
+endif
 
 $(call set-device-specific-path,CAMERA,camera,hardware/qcom/camera)
 $(call set-device-specific-path,GPS,gps,hardware/qcom/gps)


### PR DESCRIPTION
Sony's msm8226 and msm8974 devices use HALs that match the 3.10 kernel
they use. Select a custom variant here.

Change-Id: Iecfb6bdf0e989ba5231bce6e650b6926417f7f90